### PR TITLE
Let users choose their own baseline value

### DIFF
--- a/stylesheets/_rem.sass
+++ b/stylesheets/_rem.sass
@@ -2,7 +2,7 @@
 // The value should be the same as the font-size value for the html element
 // If the html element's font-size is set to 62.5% (of the browser's default font-size of 16px),
 // then the variable below would be 10px.
-$baseline-px: 10px
+$baseline-px: 10px !default
 
 =rem($property, $px-values)
   // Convert the baseline into rems

--- a/stylesheets/_rem.scss
+++ b/stylesheets/_rem.scss
@@ -2,7 +2,7 @@
 // The value should be the same as the font-size value for the html element
 // If the html element's font-size is set to 62.5% (of the browser's default font-size of 16px),
 // then the variable below would be 10px.
-$baseline-px: 10px;
+$baseline-px: 10px !default;
 
 @mixin rem($property, $px-values) {
   // Convert the baseline into rems


### PR DESCRIPTION
Added !default to baseline-px value to let users that import the _rem.sxss file use their own baseline value if they like.

Usage (this will set baseline-px to 20px without touching _rem.scss):

$baseline-px: 20px;
@import "rem";
