### PR TITLE
Allow for shorthand props containing strings or colors, plus remove extra whitespace 

### DIFF
--- a/stylesheets/_rem.sass
+++ b/stylesheets/_rem.sass
@@ -21,8 +21,8 @@ $baseline-px: 10px
 
     @each $value in $px-values
       
-      // If the value is zero, return 0
-      @if $value == 0
+      // If the value is zero or not a number, return it
+      @if $value == 0 or type-of( $value ) != "number"
         $rem-values: append($rem-values, $value)
 
       @else

--- a/stylesheets/_rem.sass
+++ b/stylesheets/_rem.sass
@@ -17,7 +17,7 @@ $baseline-px: 10px
   @else
 
     // Create an empty list that we can dump values into
-    $rem-values: unquote("")
+    $rem-values: ()
 
     @each $value in $px-values
       

--- a/stylesheets/_rem.scss
+++ b/stylesheets/_rem.scss
@@ -14,7 +14,7 @@ $baseline-px: 10px;
     #{$property}: $px-values / $baseline-rem; }
   @else {
     // Create an empty list that we can dump values into
-    $rem-values: unquote("");
+    $rem-values: ();
     @each $value in $px-values {
       // If the value is zero, return 0
       @if $value == 0 {

--- a/stylesheets/_rem.scss
+++ b/stylesheets/_rem.scss
@@ -16,8 +16,8 @@ $baseline-px: 10px;
     // Create an empty list that we can dump values into
     $rem-values: ();
     @each $value in $px-values {
-      // If the value is zero, return 0
-      @if $value == 0 {
+      // If the value is zero or not a number, return it
+      @if $value == 0 or type-of( $value ) != "number" {
         $rem-values: append($rem-values, $value); }
       @else {
         $rem-values: append($rem-values, $value / $baseline-rem); } }

--- a/test/css/screen.css
+++ b/test/css/screen.css
@@ -5,10 +5,10 @@
 
 .bar {
   margin: 15px 0 15px 0;
-  margin:  1.5rem 0 1.5rem 0;
+  margin: 1.5rem 0 1.5rem 0;
 }
 
 .baz {
-  padding: 5px 15px 5px 15px;
-  padding:  0.5rem 1.5rem 0.5rem 1.5rem;
+  border: 3px solid red;
+  border: 0.3rem solid red;
 }

--- a/test/sass/screen.sass
+++ b/test/sass/screen.sass
@@ -7,4 +7,4 @@
   +rem(margin, 15px 0 15px 0)
 
 .baz
-  +rem(padding, 5px 15px 5px 15px)
+  +rem(border, 3px solid #f00)


### PR DESCRIPTION
Hi there,

I found your mixin from this article http://webdesign.tutsplus.com/articles/typography-articles/taking-ems-even-further/. I really like it, but made a small edit so that you can convert shorthand properties like border, which contain numbers and strings, to rems. I also made a minor update to remove the extra leading whitespace before the values in the generated css.

Thanks for posting this mixin!

Ted
